### PR TITLE
Main page tree infos

### DIFF
--- a/src/components/addressModal.jsx
+++ b/src/components/addressModal.jsx
@@ -14,12 +14,12 @@ const AddressModal = (props) => {
 
 const Container = styled.div`
   position: absolute;
-  top: 100px;
-  left: 55px;
-  width: 300px;
+  bottom: 190px;
+  left: 51px;
+  width: 351px;
   height: 50px;
   background: #ffffff;
-  border: 1px solid black;
+  border: 0.5px solid gray;
   z-index: 1000;
 `
 

--- a/src/components/treeImages.jsx
+++ b/src/components/treeImages.jsx
@@ -5,26 +5,19 @@ import ExImage from '../assets/img/image.png'
 const TreeImages = () => {
   return (
     <>
-      <Container>
-        <Image src={ExImage} alt='Image' />
-        <Image src={ExImage} alt='Image' />
-        <Image src={ExImage} alt='Image' />
-      </Container>
+      <Image src={ExImage} alt='Image' />
+      <Image src={ExImage} alt='Image' />
+      <Image src={ExImage} alt='Image' />
     </>
   )
 }
-
-const Container = styled.div`
-  display: flex;
-  height: 102px;
-  margin: 13px 0 22px 22px;
-`
 
 const Image = styled.img`
   margin-right: 5px;
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
+  cursor: pointer;
 `
 
 export default TreeImages

--- a/src/components/treeInfos.jsx
+++ b/src/components/treeInfos.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
-import TreeImages from './treeImages'
 import AddressModal from './addressModal'
+import TreeImages from './treeImages'
 import { ReactComponent as BookMarkerIcon } from '../assets/icons/bookmarker.svg'
 import { ReactComponent as SharingIcon } from '../assets/icons/sharing.svg'
 import { ReactComponent as ArrowBottom } from '../assets/icons/arrowBottom.svg'
@@ -10,23 +11,29 @@ const TreeInfos = (props) => {
   const [IsClickModal, setClickModal] = useState(false)
   const [IsBookMarking, setBookMarking] = useState(false)
 
+  const navigate = useNavigate()
+
+  const goToTreePage = () => {
+    navigate('/tree')
+  }
+
   return (
     <>
       {IsClickModal && <AddressModal />}
       <Container>
         <ClickBox>
-          <Title>{props.treeTitle}</Title>
+          <Title onClick={goToTreePage}>{props.treeTitle}</Title>
           <IconBox>
             <Bookmark onClick={() => setBookMarking(!IsBookMarking)}>
               <BookMarkerSvg />
             </Bookmark>
-            <ClickTitle>저장됨</ClickTitle>
+            <IconTitle>저장됨</IconTitle>
           </IconBox>
           <IconBox>
             <Share>
               <SharingIcon />
             </Share>
-            <ClickTitle>공유</ClickTitle>
+            <IconTitle>공유</IconTitle>
           </IconBox>
         </ClickBox>
         <AddressBox>
@@ -36,19 +43,29 @@ const TreeInfos = (props) => {
             <ArrowBottom />
           </AddressArrow>
         </AddressBox>
-        <TreeImages />
+
+        <TreeImagesBox goToTreePage={goToTreePage}>
+          {/* {.map((image) => (
+            <TreeImages>image={image}</TreeImages>
+          ))} */}
+          <TreeImages />
+        </TreeImagesBox>
       </Container>
     </>
   )
 }
+
 const Container = styled.section`
+  position: absolute;
+  bottom: 114px;
+  left: 29px;
   width: 392px;
   height: 216px;
   background: #ffffff;
   box-shadow: 0px -4px 4px rgba(0, 0, 0, 0.05);
   border-radius: 10px;
-  cursor: pointer;
 `
+
 const ClickBox = styled.article`
   display: flex;
   justify-content: space-between;
@@ -62,13 +79,15 @@ const Title = styled.div`
   font-size: 25px;
   text-overflow: ellipsis;
   margin-top: 18px;
+  cursor: pointer;
 `
-
+// 저장됨, 공유
 const IconBox = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   margin-top: 18px;
+  cursor: pointer;
 `
 
 const Bookmark = styled.button`
@@ -77,6 +96,7 @@ const Bookmark = styled.button`
   background: #ffffff;
   border: none;
   padding: 0;
+  cursor: pointer;
 `
 
 const BookMarkerSvg = styled(BookMarkerIcon)`
@@ -89,9 +109,10 @@ const Share = styled.button`
   background: #ffffff;
   border: none;
   padding: 0;
+  cursor: pointer;
 `
 
-const ClickTitle = styled.span`
+const IconTitle = styled.span`
   font-size: #2c2c2c;
   font-weight: 300;
   font-size: 10px;
@@ -112,11 +133,20 @@ const Address = styled.span`
   font-weight: 300;
   font-size: 12px;
   margin: 0 4px 0 12px;
+  cursor: pointer;
 `
 
 const AddressArrow = styled.button`
   background: #ffffff;
   border: none;
   padding: 0;
+  cursor: pointer;
+`
+
+// 사진
+const TreeImagesBox = styled.div`
+  display: flex;
+  height: 102px;
+  margin: 13px 0 22px 22px;
 `
 export default TreeInfos

--- a/src/pages/MainPage/index.jsx
+++ b/src/pages/MainPage/index.jsx
@@ -1,10 +1,20 @@
 import React from 'react'
+import styled from 'styled-components'
 import TreeInfos from '../../components/treeInfos'
 
 export const MainPage = () => {
   return (
     <>
-      <TreeInfos />
+      <Container>
+        <TreeInfos />
+      </Container>
     </>
   )
 }
+
+const Container = styled.main`
+  width: 421px;
+  height: 852px;
+  padding: 24px 14px 14px 0;
+  border: 1px solid black;
+`


### PR DESCRIPTION
<!--피알 완료 전 develop 브랜치에 머지하는지 꼭 확인해주세요!-->  

## ⭐ 개요

design,feat (mainPage_treeInfos)

## 📋 작업사항

- [ ] 전체적인 테두리와 트리간단정보 위치 수정
 
- [ ] 트리간단정보 클릭 => 상세페이지로 이동

## 😉 전달사항

1. 명확하게 보기 위해 테두리에 ```border: 1px solid black;``` 을 추가하였으며,
추후 제거 할 예정입니다.

3. 저장하기, 공유하기 버튼, 주소누르면 모달이 생성되는 부분 때문에
컴포넌트 전체를 누를 경우 상세페이지로 가는 것이 아니라, 
**타이틀(어쩌구 트리) 또는 사진 컴포넌트를 눌렀을 때** 상세페이지로 이동하도록 구현하였습니다.

## 💻 작업내용


<img src="https://user-images.githubusercontent.com/82799961/204141074-f0b2952a-ac99-4198-a528-a17d45af1f50.png" width="30%">



