### PR TITLE
design/방문자 사진 컴포넌트 디자인/#19

### DIFF
--- a/src/components/Review/ImgList/index.jsx
+++ b/src/components/Review/ImgList/index.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { ReviewImg } from '../../common/TreeImg'
+import { ReviewTitle } from '../ReviewTitle'
+import * as S from './style'
+
+export const ImgList = () => {
+  const arr = Array.from({ length: 6 }, (_, i) => i)
+
+  return (
+    <S.ImgSection>
+      <ReviewTitle title='방문자 사진' total={17} />
+      <S.ImgItems>
+        {arr.map((_, i) => (
+          <ReviewImg key={i} />
+        ))}
+      </S.ImgItems>
+      <S.ButtonWrapper>
+        <S.MoreButton>방문자 사진 더보기</S.MoreButton>
+      </S.ButtonWrapper>
+    </S.ImgSection>
+  )
+}

--- a/src/components/Review/ImgList/style.js
+++ b/src/components/Review/ImgList/style.js
@@ -1,0 +1,26 @@
+import styled from 'styled-components'
+
+export const ImgSection = styled.section`
+  width: 100%;
+  text-align: center;
+`
+
+export const ImgItems = styled.ul`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 5px;
+  padding: 14px 24px;
+`
+
+export const ButtonWrapper = styled.div`
+  width: 100%;
+  padding: 0 24px;
+`
+
+export const MoreButton = styled.button`
+  width: 100%;
+  padding: 11px 0;
+  background-color: #f4f4f4;
+  border: none;
+  border-radius: 5px;
+`

--- a/src/components/Review/ReviewTitle/index.jsx
+++ b/src/components/Review/ReviewTitle/index.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { Containter, Title, Total } from './style'
+
+export const ReviewTitle = ({ title, total }) => {
+  return (
+    <Containter>
+      <Title>{title}</Title>
+      <Total>{total}</Total>
+    </Containter>
+  )
+}

--- a/src/components/Review/ReviewTitle/style.js
+++ b/src/components/Review/ReviewTitle/style.js
@@ -1,0 +1,21 @@
+import styled from 'styled-components'
+
+export const Containter = styled.div`
+  width: 100%;
+  display: flex;
+  gap: 13px;
+  padding: 15px 24px;
+  border-top: 1px solid #f0f0f0;
+  border-bottom: 1px solid #f0f0f0;
+`
+
+export const Title = styled.h3`
+  font-size: 14px;
+  font-weight: 700;
+`
+
+export const Total = styled.p`
+  font-size: 14px;
+  font-weight: 700;
+  color: #60b257;
+`

--- a/src/components/common/TreeImg/index.jsx
+++ b/src/components/common/TreeImg/index.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { Image, ImgWrapper } from './style'
+import ExImage from '../../../assets/img/image.png'
+
+export const ReviewImg = () => {
+  return (
+    <ImgWrapper>
+      <Image src={ExImage} alt='Image' />
+    </ImgWrapper>
+  )
+}

--- a/src/components/common/TreeImg/style.js
+++ b/src/components/common/TreeImg/style.js
@@ -1,0 +1,17 @@
+import styled from 'styled-components'
+
+export const ImgWrapper = styled.li`
+  display: block;
+  padding-top: 100%;
+  position: relative;
+  overflow: hidden;
+`
+
+export const Image = styled.img`
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  object-fit: cover;
+  top: 0;
+  left: 0;
+`

--- a/src/pages/TreePage/index.jsx
+++ b/src/pages/TreePage/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
+import { ImgList } from '../../components/Review/ImgList'
 
 export const TreePage = () => {
-  return <div>TreePage(2)</div>
+  return <ImgList />
 }

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -12,9 +12,9 @@ export const Router = () => {
           <Route path='/landing' element={<LandingPage />} />
           <Route path='/map' element={<MapPage />} />
           <Route path='/sign-in' element={<SignIn />} />
+          <Route path='/tree' element={<TreePage />} />
           <Route element={<RequireAuth />}>
             <Route path='/my' element={<MyPage />} />
-            <Route path='/tree' element={<TreePage />} />
           </Route>
         </Route>
       </Routes>


### PR DESCRIPTION
<!--피알 완료 전 develop 브랜치에 머지하는지 꼭 확인해주세요!-->  

## ⭐ 개요

treeInfoPage components_reviewImgs

## 📋 작업사항

- [x] 방문자 사진 타이틀 컴포넌트 생성
- [x] 사진 공통 컴포넌트로 만들기
- [x] 사진 더보기 버튼 만들기
- [x] 방문자 사진 섹션으로 합치기

## 😉 전달사항

padding-top 이용해서 이미지 반응형으로 만들었습니다.

## 💻 작업내용

<img width="486" alt="스크린샷 2022-11-28 오후 4 31 09" src="https://user-images.githubusercontent.com/97153666/204219123-e37385b1-b1b4-4bce-ba6a-1b91df501ad7.png">

방문자 사진 컴포넌트 작업했습니다.


